### PR TITLE
introducing globals + refactoring

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/r3kzi/elasticsearch-provisioner/pkg/cfg"
 	"github.com/r3kzi/elasticsearch-provisioner/pkg/user"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/util/globals"
 	"os"
 )
 
@@ -23,8 +24,12 @@ func main() {
 	// NewCredentials returns a pointer to a new Credentials object wrapping the AssumeRoleProvider
 	creds := stscreds.NewCredentials(session.Must(session.NewSession()), config.AWS.RoleARN)
 
+	// Make this information globally accessible
+	globals.SetConfig(config)
+	globals.SetCredentials(creds)
+
 	// Creating user
-	if err := user.Create(config, creds); err != nil {
+	if err := user.Create(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -1,14 +1,18 @@
 package http
 
 import (
+	"bytes"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/signer/v4"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/util/globals"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
 )
+
+var region = globals.GetConfig().AWS.Region
+var signer = v4.NewSigner(globals.GetCredentials())
 
 // NewRequest will create a new HTTP request based on an URL and a Body string
 func NewRequest(url string, body string) (*http.Request, error) {
@@ -22,9 +26,13 @@ func NewRequest(url string, body string) (*http.Request, error) {
 
 // SignRequest will sign a HTTP requests with an assumed role for a specific AWS Region
 // using AWS Signature V4 signing process
-func SignRequest(req *http.Request, body string, creds *credentials.Credentials, service string, region string) (*http.Request, error) {
-	signer := v4.NewSigner(creds)
-	_, err := signer.Sign(req, strings.NewReader(body), service, region, time.Now())
+func SignRequest(req *http.Request, service string) (*http.Request, error) {
+	body, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = signer.Sign(req, bytes.NewReader(body), service, region, time.Now())
 	if err != nil {
 		return nil, fmt.Errorf("error signing http request, %s", err)
 	}
@@ -43,5 +51,25 @@ func DoRequest(req *http.Request) error {
 		bytes, _ := ioutil.ReadAll(resp.Body)
 		return fmt.Errorf("returned code was %s - message was %s", resp.Status, string(bytes))
 	}
+	return nil
+}
+
+// FulfillRequest is a helper function which covers all required steps
+func FulfillRequest(url string, body string, service string) error {
+	request, err := NewRequest(url, body)
+	if err != nil {
+		return err
+	}
+
+	signRequest, err := SignRequest(request, service)
+	if err != nil {
+		return err
+	}
+
+	err = DoRequest(signRequest)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	url     = "https://elasticsearch.com"
+	url     = "https://elasticsearch"
 	body    = "body"
 	service = "es"
 )

--- a/pkg/http/http_test.go
+++ b/pkg/http/http_test.go
@@ -2,6 +2,8 @@ package http
 
 import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/cfg"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/util/globals"
 	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
@@ -12,11 +14,21 @@ import (
 )
 
 const (
-	url     = "https://elasticsearch"
+	url     = "https://elasticsearch.com"
 	body    = "body"
 	service = "es"
-	region  = "eu-west-1"
 )
+
+var configuration = &cfg.Config{
+	Elasticsearch: cfg.Elasticsearch{},
+	AWS:           cfg.AWS{Region: "eu-west-1"},
+	Users:         []map[string]cfg.User{},
+}
+
+func init() {
+	globals.SetConfig(configuration)
+	globals.SetCredentials(credentials.NewCredentials(&CredentialsTestProvider{}))
+}
 
 type CredentialsTestProvider struct{}
 
@@ -39,11 +51,10 @@ func TestNewRequest(t *testing.T) {
 }
 
 func TestSignRequest(t *testing.T) {
-	creds := credentials.NewCredentials(&CredentialsTestProvider{})
 	request, err := NewRequest(url, body)
 	assert.Nil(t, err)
 
-	signRequest, err := SignRequest(request, body, creds, service, region)
+	signRequest, err := SignRequest(request, service)
 	assert.Nil(t, err)
 	assert.NotNil(t, signRequest)
 	assert.NotEmpty(t, signRequest.Header.Get("Authorization"))
@@ -57,4 +68,15 @@ func TestDoRequest(t *testing.T) {
 	req, _ := http.NewRequest(http.MethodPut, server.URL, strings.NewReader(""))
 	err := DoRequest(req)
 	assert.Nil(t, err)
+}
+
+func TestFulfillRequest(t *testing.T) {
+	// TODO: not really required while FulfillRequest method is just a composition of the methods above
+	/*
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		err := FulfillRequest(server.URL, "", service)
+		assert.Nil(t, err)
+	*/
 }

--- a/pkg/user/user.go
+++ b/pkg/user/user.go
@@ -3,15 +3,16 @@ package user
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/r3kzi/elasticsearch-provisioner/pkg/cfg"
 	"github.com/r3kzi/elasticsearch-provisioner/pkg/http"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/util/globals"
 )
 
 const userAPIEndpoint = "_opendistro/_security/api/internalusers"
 
+var config = globals.GetConfig()
+
 // Create will create all User using the http package
-func Create(config *cfg.Config, creds *credentials.Credentials) error {
+func Create() error {
 	for _, user := range config.Users {
 		for key, value := range user {
 			jsonUser, err := json.Marshal(value)
@@ -22,17 +23,7 @@ func Create(config *cfg.Config, creds *credentials.Credentials) error {
 			url := fmt.Sprintf("%s/%s/%s", config.Elasticsearch.Endpoint, userAPIEndpoint, key)
 			body := string(jsonUser)
 
-			request, err := http.NewRequest(url, string(jsonUser))
-			if err != nil {
-				return fmt.Errorf("for user: %s - %s", key, err)
-			}
-
-			signRequest, err := http.SignRequest(request, body, creds, "es", config.AWS.Region)
-			if err != nil {
-				return fmt.Errorf("for user: %s - %s", key, err)
-			}
-
-			err = http.DoRequest(signRequest)
+			err = http.FulfillRequest(url, body, "es")
 			if err != nil {
 				return fmt.Errorf("for user: %s - %s", key, err)
 			}

--- a/pkg/user/user_test.go
+++ b/pkg/user/user_test.go
@@ -3,6 +3,7 @@ package user
 import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/r3kzi/elasticsearch-provisioner/pkg/cfg"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/util/globals"
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,7 @@ import (
 	"testing"
 )
 
-var config = cfg.Config{
+var configuration = &cfg.Config{
 	Elasticsearch: cfg.Elasticsearch{},
 	AWS:           cfg.AWS{},
 	Users: []map[string]cfg.User{
@@ -19,6 +20,11 @@ var config = cfg.Config{
 			"erica": cfg.User{Password: "password", BackendRoles: []string{"backend-role-2", "backend-role-3"}},
 		},
 	},
+}
+
+func init() {
+	globals.SetConfig(configuration)
+	globals.SetCredentials(credentials.NewCredentials(&CredentialsTestProvider{}))
 }
 
 type CredentialsTestProvider struct{}
@@ -52,11 +58,9 @@ func TestCreate(t *testing.T) {
 	for _, test := range tests {
 		server := httptest.NewServer(test.Handler)
 
-		config.Elasticsearch.Endpoint = server.URL
+		configuration.Elasticsearch.Endpoint = server.URL
 
-		creds := credentials.NewCredentials(&CredentialsTestProvider{})
-
-		err := Create(&config, creds)
+		err := Create()
 		switch test.StatusCode {
 		case http.StatusOK:
 			assert.Nil(t, err)

--- a/pkg/util/globals/globals.go
+++ b/pkg/util/globals/globals.go
@@ -1,0 +1,25 @@
+package globals
+
+import (
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/r3kzi/elasticsearch-provisioner/pkg/cfg"
+)
+
+var config *cfg.Config = &cfg.Config{}
+var cred *credentials.Credentials = &credentials.Credentials{}
+
+func GetConfig() *cfg.Config {
+	return config
+}
+
+func GetCredentials() *credentials.Credentials {
+	return cred
+}
+
+func SetConfig(configuration *cfg.Config) {
+	config = configuration
+}
+
+func SetCredentials(credentials *credentials.Credentials) {
+	cred = credentials
+}


### PR DESCRIPTION
I have changed the way you are injecting required information like the user list and aws credentials. If we define globals for that, it will save us a lot of headache in future.